### PR TITLE
feat: relicense project to Apache-2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,120 +1,202 @@
-# Fair Core License, Version 1.0, ALv2 Future License
+# Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-## Abbreviation
+## TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-FCL-1.0-ALv2
+### 1. Definitions.
 
-## Notice
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-Copyright 2025-present Brightfame
+"Licensor" shall mean the copyright owner or entity granting the License.
 
-## Terms and Conditions
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-### Licensor ("We")
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
 
-The party offering the Software under these Terms and Conditions.
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
 
-### The Software
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
 
-The "Software" is each version of the software that we make available under
-these Terms and Conditions, as indicated by our inclusion of these Terms and
-Conditions with the Software.
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(which shall not include any other work that is under separate
+copyright notice and is not otherwise authorized under the License).
 
-### License Grant
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based upon (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and derivative works thereof.
 
-Subject to your compliance with this License Grant and the Limitations,
-Patents, Redistribution and Trademark clauses below, we hereby grant you the
-right to use, copy, modify, create derivative works, publicly perform, publicly
-display and redistribute the Software for any Permitted Purpose identified
-below.
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work,
+but excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
 
-### Permitted Purpose
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
 
-A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
-means making the Software available to others in a commercial product or
-service that:
+### 2. Grant of Copyright License.
 
-1. substitutes for the Software;
+Subject to the terms and conditions of this License, each Contributor
+hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to use, reproduce, prepare
+Derivative Works of, publicly display, publicly perform, sublicense,
+and distribute the Work and such Derivative Works in Source or Object
+form.
 
-2. substitutes for any other product or service we offer using the Software
-   that exists as of the date we make the Software available; or
+### 3. Grant of Patent License.
 
-3. offers the same or substantially similar functionality as the Software.
+Subject to the terms and conditions of this License, each Contributor
+hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily
+infringed by their Contribution(s) alone or by combination of their
+Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+the Work or a Contribution incorporated within the Work constitutes
+direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
 
-Permitted Purposes specifically include using the Software:
+### 4. Redistribution.
 
-1. for your internal use and access;
+You may reproduce and distribute copies of the Work or Derivative
+Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
 
-2. for non-commercial education;
+1. You must give any other recipients of the Work or Derivative Works
+   a copy of this License; and
 
-3. for non-commercial research; and
+2. You must cause any modified files to carry prominent notices
+   stating that You changed the files; and
 
-4. in connection with professional services that you provide to a licensee
-   using the Software in accordance with these Terms and Conditions.
+3. You must retain, in the Source form of any Derivative Works that
+   You distribute, all copyright, patent, trademark, and attribution
+   notices from the Source form of the Work, excluding those notices
+   that do not pertain to any part of the Derivative Works; and
 
-### Limitations
+4. If the Work includes a "NOTICE" text file as part of its
+   distribution, then any Derivative Works that You distribute must
+   include a readable copy of the attribution notices contained
+   within such NOTICE file, excluding those notices that do not
+   pertain to any part of the Derivative Works, in at least one
+   of the following places: within a NOTICE text file distributed
+   as part of the Derivative Works; within the Source form or
+   documentation, if provided along with the Derivative Works; or,
+   within a display generated by the Derivative Works, if and
+   wherever such third-party notices normally appear. The contents
+   of the NOTICE file are for informational purposes only and
+   do not modify the License. You may add Your own attribution
+   notices within Derivative Works that You distribute, alongside
+   or as an addendum to the NOTICE text from the Work, provided
+   that such additional attribution notices cannot be construed
+   as modifying the License.
 
-You must not move, change, disable, or circumvent the license key functionality
-in the Software; or modify any portion of the Software protected by the license
-key to:
+You may add Your own copyright notice to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
 
-1. enable access to the protected functionality without a valid license key; or
+### 5. Submission of Contributions.
 
-2. remove the protected functionality.
+Unless You explicitly state otherwise, any Contribution intentionally
+submitted for inclusion in the Work by You to the Licensor shall be
+under the terms and conditions of this License, without any additional
+terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
 
-### Patents
+### 6. Trademarks.
 
-To the extent your use for a Permitted Purpose would necessarily infringe our
-patents, the license grant above includes a license under our patents. If you
-make a claim against any party that the Software infringes or contributes to
-the infringement of any patent, then your patent license to the Software ends
-immediately.
+This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except
+as required for reasonable and customary use in describing the origin
+of the Work and reproducing the content of the NOTICE file.
 
-### Redistribution
+### 7. Disclaimer of Warranty.
 
-The Terms and Conditions apply to all copies, modifications and derivatives of
-the Software.
+Unless required by applicable law or agreed to in writing, Licensor
+provides the Work (and each Contributor provides its Contributions)
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for
+determining the appropriateness of using or redistributing the Work
+and assume any risks associated with Your exercise of permissions under
+this License.
 
-If you redistribute any copies, modifications or derivatives of the Software,
-you must include a copy of or a link to these Terms and Conditions and not
-remove any copyright or other proprietary notices provided in or with the
-Software.
+### 8. Limitation of Liability.
 
-### Disclaimer
+In no event and under no legal theory, whether in tort (including
+negligence), contract, or otherwise, unless required by applicable law
+(such as deliberate and grossly negligent acts) or agreed to in writing,
+shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or
+inability to use the Work (including but not limited to damages for
+loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such
+Contributor has been advised of the possibility of such damages.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
-PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+### 9. Accepting Warranty or Additional Support.
 
-IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
-SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
-EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+While redistributing the Work or Derivative Works thereof, You may
+choose to offer, and charge a fee for, acceptance of support, warranty,
+indemnity, or other liability obligations and/or rights consistent with
+this License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf of
+any other Contributor, and only if You agree to indemnify, defend, and
+hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such
+warranty or additional support.
 
-In the event the provision of this Disclaimer section is unenforceable under
-applicable law, the licenses granted herein are void.
+## END OF TERMS AND CONDITIONS
 
-### Trademarks
+---
 
-Except for displaying the License Details and identifying us as the origin of
-the Software, you have no right under these Terms and Conditions to use our
-trademarks, trade names, service marks or product names.
+Copyright 2025 Rob Morgan
 
-## Grant of Future License
-
-We hereby irrevocably grant you an additional license to use the Software,
-under the Apache License, Version 2.0, that is effective on the second
-anniversary of the date we make the Software available. On or after that date,
-you may use the Software under the Apache License, Version 2.0, in which case
-the following will apply:
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License.
-
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ save both time and money.
 
 ## License
 
-[Fair Core License, Version 1.0, ALv2 Future License](https://github.com/robmorgan/infraspec/blob/main/LICENSE.md)
+[Apache License 2.0](https://github.com/robmorgan/infraspec/blob/main/LICENSE.md)

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -55,7 +55,7 @@ const navbar = (
     // ... Your additional navbar options
   />
 )
-const footer = <Footer>{new Date().getFullYear()} © Brightfame.</Footer>
+const footer = <Footer>{new Date().getFullYear()} © Rob Morgan.</Footer>
  
 export default async function RootLayout({ children }) {
   return (


### PR DESCRIPTION
Relicensed the project from Fair Core License to Apache License 2.0 as requested in issue #4.

## Changes:
- Replaced Fair Core License with Apache License 2.0
- Updated license reference in README.md
- Updated copyright notice in website footer from Brightfame to Rob Morgan

Closes #4

Generated with [Claude Code](https://claude.ai/code)