### PR TITLE
feat(http): add authorization bearer support

### DIFF
--- a/features/http/api_tests.feature
+++ b/features/http/api_tests.feature
@@ -24,6 +24,14 @@ Feature: API Testing Example
     And the HTTP response should be valid JSON
     And the HTTP response should contain "token"
 
+  Scenario: Test Bearer token authentication
+    Given I have a HTTP endpoint at "http://localhost:8000/bearer"
+    And I am authenticated with a valid bearer token
+    When I send a GET request
+    Then the HTTP response status should be 200
+    And the HTTP response should be valid JSON
+    And the HTTP response should contain "authenticated"
+
   Scenario: Test file upload endpoint
     Given I have a HTTP endpoint at "http://localhost:8000/post"
     And I have a file "../../examples/http/test-file.txt" as field "file"

--- a/pkg/httphelpers/client.go
+++ b/pkg/httphelpers/client.go
@@ -22,6 +22,7 @@ type HttpRequestOptions struct {
 	File        *File
 	RequestBody []byte
 	BasicAuth   *BasicAuth
+	BearerToken string
 }
 
 type BasicAuth struct {
@@ -151,6 +152,11 @@ func (h *HttpClient) Do(ctx context.Context, opts *HttpRequestOptions) (*HttpRes
 	// Set basic auth credentials if specified
 	if opts.BasicAuth != nil {
 		req.SetBasicAuth(opts.BasicAuth.Username, opts.BasicAuth.Password)
+	}
+
+	// Set Bearer token if specified
+	if opts.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.BearerToken)
 	}
 
 	// Send request

--- a/test/testhelpers/test_helpers.go
+++ b/test/testhelpers/test_helpers.go
@@ -25,10 +25,11 @@ func GetTestConfig() *config.Config {
 func SetupAwsTestEnvironment() {
 	// Only set if not already present (allows external override)
 	envVars := map[string]string{
-		"AWS_ACCESS_KEY_ID":     "test",
-		"AWS_SECRET_ACCESS_KEY": "test",
-		"AWS_DEFAULT_REGION":    "us-east-1",
-		"AWS_ENDPOINT_URL":      "http://localhost:4566",
+		"AWS_ACCESS_KEY_ID":      "test",
+		"AWS_SECRET_ACCESS_KEY":  "test",
+		"AWS_DEFAULT_REGION":     "us-east-1",
+		"AWS_ENDPOINT_URL":       "http://localhost:4566",
+		"INFRASPEC_BEARER_TOKEN": "test-token",
 	}
 
 	for key, value := range envVars {
@@ -46,7 +47,7 @@ func CleanupAwsTestEnvironment() {
 	}
 }
 
-// SetupAWSTests sets up the AWS test environment and returns the config
+// SetupAWSTestsAndConfig sets up the AWS test environment and returns the config
 func SetupAWSTestsAndConfig() *config.Config {
 	SetupAwsTestEnvironment()
 	return GetTestConfig()


### PR DESCRIPTION
InfraSpec now supports Bearer token authentication for HTTP requests. This allows you to test API endpoints that require Bearer token authentication.

## Usage

### Setting Bearer Token

Use the `I am authenticated with a valid bearer token` step to configure Bearer token authentication. This step requires the `INFRASPEC_BEARER_TOKEN` environment variable to be set:

```gherkin
Given I have a HTTP endpoint at "https://api.example.com/protected"
And I am authenticated with a valid bearer token
When I send a GET request
Then the HTTP response status should be 200
```

### Environment Variable Setup

Before running scenarios that use Bearer token authentication, set the `INFRASPEC_BEARER_TOKEN` environment variable:

```bash
export INFRASPEC_BEARER_TOKEN="your-secret-token-here"
```

### Complete Example

```gherkin
Feature: API with Bearer Token Authentication

Scenario: Test protected API endpoint
  Given I have a HTTP endpoint at "https://api.example.com/protected"
  And I am authenticated with a valid bearer token
  And I set the headers to
    | Name         | Value            |
    | Content-Type | application/json |
  When I send a GET request
  Then the HTTP response status should be 200
  And the HTTP response should be valid JSON
  And the HTTP response should contain "authenticated"
```